### PR TITLE
Dockerfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.7
 COPY . /app
 WORKDIR /app
 
+RUN apt-get update
+RUN apt-get install python3-systemd
+
 RUN python setup.py install
 
 ENV APP=tornado-us

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM python:3.7
 COPY . /app
 WORKDIR /app
 
-RUN apt-get update
-RUN apt-get install python3-systemd
-
 RUN python setup.py install
 
 ENV APP=tornado-us

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ ENV USERNAME=
 ENV PASSWORD=
 ENV MQTT_HOST=
 ENV MQTT_USER=
+VOLUME [ "/opt/hisense" ]
 
-CMD rm -Rf config_*.json && \
-python -m aircon discovery $APP $USERNAME $PASSWORD && \   
-configs= && for i in $(find . -maxdepth 1 -type f -name "config_*.json" -exec basename {} \;); do configs="$configs --config $i --type $TYPE"; done && \
+CMD \
+if [ -z "$(cd /opt/hisense/ && find . -maxdepth 1 -type f -name "config_*.json")" ]; then \
+rm -Rf config_*.json && python -m aircon discovery $APP $USERNAME $PASSWORD && mv config_*.json /opt/hisense/; \
+fi; \   
+configs= ; for i in $(find /opt/hisense/ -maxdepth 1 -type f -name "config_*.json" -exec basename {} \;); do configs="$configs --config /opt/hisense/$i --type $TYPE"; done ; \
 python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host $MQTT_HOST --mqtt_user $MQTT_USER $configs

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ VOLUME [ "/opt/hisense" ]
 
 CMD \
 if [ -z "$(cd /opt/hisense/ && find . -maxdepth 1 -type f -name "config_*.json")" ]; then \
-rm -Rf config_*.json && python -m aircon discovery $APP $USERNAME $PASSWORD && mv config_*.json /opt/hisense/; \
+rm -f config_*.json && python -m aircon discovery $APP $USERNAME $PASSWORD && mv config_*.json /opt/hisense/; \
 fi; \   
 configs= ; for i in $(find /opt/hisense/ -maxdepth 1 -type f -name "config_*.json" -exec basename {} \;); do configs="$configs --config /opt/hisense/$i --type $TYPE"; done ; \
 python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host $MQTT_HOST --mqtt_user $MQTT_USER $configs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.7
+
+COPY . /app
+WORKDIR /app
+
+RUN python setup.py install
+
+ENV APP=tornado-us
+ENV TYPE=ac
+ENV PORT=8888
+ENV USERNAME=
+ENV PASSWORD=
+ENV MQTT_HOST=
+ENV MQTT_USER=
+
+
+CMD rm -Rf config_*.json && \
+python -m aircon discovery $APP $USERNAME $PASSWORD && \   
+configs= && for i in $(find . -maxdepth 1 -type f -name "config_*.json" -exec basename {} \;); do configs="$configs --config $i --type $TYPE"; done && \
+python -m aircon run --port $PORT --mqtt_host $MQTT_HOST --mqtt_user $MQTT_USER $configs

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 
 RUN python setup.py install
 
+ENV PLATFORM=docker
+
 ENV APP=tornado-us
 ENV TYPE=ac
 ENV PORT=8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ RUN python setup.py install
 ENV APP=tornado-us
 ENV TYPE=ac
 ENV PORT=8888
+ENV LOG_LEVEL=WARNING
 ENV USERNAME=
 ENV PASSWORD=
 ENV MQTT_HOST=
 ENV MQTT_USER=
 
-
 CMD rm -Rf config_*.json && \
 python -m aircon discovery $APP $USERNAME $PASSWORD && \   
 configs= && for i in $(find . -maxdepth 1 -type f -name "config_*.json" -exec basename {} \;); do configs="$configs --config $i --type $TYPE"; done && \
-python -m aircon run --port $PORT --mqtt_host $MQTT_HOST --mqtt_user $MQTT_USER $configs
+python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host $MQTT_HOST --mqtt_user $MQTT_USER $configs

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     license='GPL 3.0',
     packages=setuptools.find_packages(),
     install_requires=[
-        'aiohttp==3.6.2', 'dataclasses_json', 'pycryptodome', 'paho-mqtt==1.5.0', 'tenacity'
+        'aiohttp==3.6.2', 'dataclasses_json', 'pycryptodome', 'paho-mqtt==1.5.0', 'tenacity','retry'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Hi,
I've added support for Dockerfile.
Usefull for multiple ACs as well.

To build as docker image:
`docker build -t aircon:latest .`

To run the container
```
docker run \
-e USERNAME=example@example.com \
-e PASSWORD="1234"\
-e APP=tornado-us \
-e TYPE=ac \
-e LOG_LEVEL=WARNING \
-e MQTT_HOST=192.168.1.1\
-e MQTT_USER=username:pass \
-e PORT=8888 \
-v /opt/hisense:/opt/hisense \
--net host \
--name aircon -it aircon:latest
```
This will autorun the discovery for the specified app and type if there isn't any config file in the mounted folder.
Then will run the server with all the config files that were generated.
Also added another install requirement.. it seems like it does not run without _retry_ installed...
Will be glad to hear what you think.