### PR TITLE
Fix: allow keep alive error to continue to the next device

### DIFF
--- a/aircon/notifier.py
+++ b/aircon/notifier.py
@@ -74,9 +74,9 @@ class Notifier:
     self._running = True
     async with self._condition:
       while self._running:
-        queues_empty = True
-        try:
-          for entry in self._configurations:
+        for entry in self._configurations:
+          try:    
+            queues_empty = True
             now = time.time()
             queue_size = entry.device.commands_queue.qsize()
             if queue_size > 1:
@@ -84,17 +84,17 @@ class Notifier:
             if now - entry.last_timestamp >= self._KEEP_ALIVE_INTERVAL or queue_size > 0:
               await self._perform_request(session, entry)
               entry.last_timestamp = now
-        except:
-          logging.exception('[KeepAlive] Failed to send local_reg keep alive to the AC.')
-        if queues_empty:
-          logging.debug('[KeepAlive] Waiting for notification or timeout')
-          try:
-            await asyncio.wait_for(self._condition.wait(), timeout=self._KEEP_ALIVE_INTERVAL)
-          except TimeoutError:
-            pass
-        else:
-          # give some time to clean up the queues
-          await asyncio.sleep(self._TIME_TO_HANDLE_REQUESTS)
+          except:
+            logging.exception('[KeepAlive] Failed to send local_reg keep alive to the AC.')
+          if queues_empty:
+            logging.debug('[KeepAlive] Waiting for notification or timeout')
+            try:
+              await asyncio.wait_for(self._condition.wait(), timeout=self._KEEP_ALIVE_INTERVAL)
+            except TimeoutError:
+              pass
+          else:
+            # give some time to clean up the queues
+            await asyncio.sleep(self._TIME_TO_HANDLE_REQUESTS)
 
   async def stop(self):
     self._running = False


### PR DESCRIPTION
Hi @deiger 
Please see the PR suggestion.
As I said, not really a python developer, so make any changes you like :)

This should solve the issue for #60 
The loop exception handling seems to skip the following devices.
I guessed that the queue_emty variable should have been inside the loop as well.

As I suggested in the #60 issue, I would set the MQTT device availability to off for HA.

