### PR TITLE
Respect _KEEP_ALIVE_INTERVAL for down AC.

### DIFF
--- a/aircon/notifier.py
+++ b/aircon/notifier.py
@@ -81,8 +81,8 @@ class Notifier:
             if queue_size > 1:
               queues_empty = False
             if now - config.last_timestamp >= self._KEEP_ALIVE_INTERVAL or queue_size > 0:
-              await self._perform_request(session, config)
               config.last_timestamp = now
+              await self._perform_request(session, config)
           except:
             logging.exception('[KeepAlive] Failed to send local_reg keep alive to the AC.')
             config.device.available = False

--- a/aircon/notifier.py
+++ b/aircon/notifier.py
@@ -80,7 +80,7 @@ class Notifier:
             queue_size = config.device.commands_queue.qsize()
             if queue_size > 1:
               queues_empty = False
-            if now - config.last_timestamp >= self._KEEP_ALIVE_INTERVAL or queue_size > 0:
+            if now - config.last_timestamp >= self._KEEP_ALIVE_INTERVAL or (queue_size > 0 and config.device.available):
               config.last_timestamp = now
               await self._perform_request(session, config)
           except:

--- a/aircon/notifier.py
+++ b/aircon/notifier.py
@@ -83,11 +83,10 @@ class Notifier:
             if now - config.last_timestamp >= self._KEEP_ALIVE_INTERVAL or (queue_size > 0 and config.device.available):
               config.last_timestamp = now
               await self._perform_request(session, config)
+              config.device.available = True
           except:
             logging.exception('[KeepAlive] Failed to send local_reg keep alive to the AC.')
             config.device.available = False
-          else:
-            config.device.available = True
         if queues_empty:
           logging.debug('[KeepAlive] Waiting for notification or timeout')
           try:


### PR DESCRIPTION
Hi @deiger 
From the code, it looks like if there is a network error connecting the AC, the loop will continue without any wait.
So the `_KEEP_ALIVE_INTERVAL` is not respected. I saw the logs just looping through the keep alive.
I've updated the code as in the PR to fix that.

Also, I can still see the keep-alive (after my changes) happens too fast.
Maybe it is something with the queue_size?