### PR TITLE
Fix: setting fglair fan_only mode

### DIFF
--- a/aircon/mqtt_client.py
+++ b/aircon/mqtt_client.py
@@ -79,8 +79,7 @@ class MqttClient(mqtt.Client):
                           value,
                           retain: bool = False) -> None:
     if isinstance(value, enum.Enum):
-      payload = 'fan_only' if (value is AcWorkMode.FAN or
-                               value is FglOperationMode.FAN) else value.name.lower()
+      payload = 'fan_only' if value is AcWorkMode.FAN else value.name.lower()
     else:
       payload = str(value)
     self.publish(self._mqtt_topics['pub'].format(mac_address, property_name),

--- a/aircon/properties.py
+++ b/aircon/properties.py
@@ -125,7 +125,7 @@ class FglOperationMode(enum.IntEnum):
   AUTO = 2
   COOL = 3
   DRY = 4
-  FAN = 5
+  FAN_ONLY = 5
   HEAT = 6
 
 


### PR DESCRIPTION
This fixes #168. I'm not sure if I didn't miss anything.

Tested locally, setting FAN_ONLY mode works correctly with this change:
```
tschut@laptop:~$ curl -ik 'http://localhost:8888/hisense/command?property=operation_mode&value=FAN_ONLY'
{"queued_commands": 1}

tschut@laptop:~$ curl -ik 'http://localhost:8888/hisense/status'
{"devices": [{"ip": "192.168.0.205", "props": {"operation_mode": "FAN_ONLY", "fan_speed": "MEDIUM", "adjust_temperature": 23, "af_vertical_move_step1": 0, "af_horizontal_move_step1": 0, "economy_mode": "OFF"}}]}
```

I also see the FAN_ONLY mode updating correctly in the fglair app on my phone.