### PR TITLE
feat: Add option to specify local ip address to AC units to connect to

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Use this method if the docker setup above does not work for you.
    - `--mqtt_topic` - The MQTT root topic. Default is &quot;hisense_ac&quot;. The server will listen on topics
      &lt;{mqtt_topic}/{property_name}/command&gt; and publish to &lt;{mqtt_topic}/{property_name}/status&gt;.
    - `--log_level` - The minimal log level to send to syslog. Default is WARNING.
+   - `--local_ip` - The local IP address to report to the AC unit(s) as target server. Useful in case the server running this application has multiple IP addresses (e.g. in multiple VLANs), since some/most(?) AC units will refuse to report to an IP address outside of their subnet.
 1. Access e.g. using curl:
    ```bash
    curl -ik 'http://localhost:8888/hisense/status'

--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -64,6 +64,10 @@ def ParseArguments() -> argparse.Namespace:
 
   parser_run = subparsers.add_parser('run', help='Runs the server to control the device')
   parser_run.add_argument('-p', '--port', required=True, type=int, help='Port for the server.')
+  parser_run.add_argument('--local_ip',
+                          required=False,
+                          default=None,
+                          help='The local IP address to report to the AC unit(s) as target server. Useful in case the server running this application has multiple IP addresses (e.g. in multiple VLANs), since some/most(?) AC units will refuse to report to an IP address outside of their subnet.')
   group_device = parser_run.add_argument_group('Device', 'Arguments that are related to the device')
   group_device.add_argument('--config', required=True, action='append', help='LAN Config file.')
   group_device.add_argument('--type',
@@ -161,7 +165,7 @@ async def mqtt_loop(mqtt_client: MqttClient):
 
 
 async def run(parsed_args):
-  notifier = Notifier(parsed_args.port)
+  notifier = Notifier(parsed_args.port, parsed_args.local_ip)
   devices = []
   for i in range(len(parsed_args.config)):
     with open(parsed_args.config[i], 'rb') as f:

--- a/aircon/notifier.py
+++ b/aircon/notifier.py
@@ -36,13 +36,13 @@ class Notifier:
   _KEEP_ALIVE_INTERVAL = 10.0
   _TIME_TO_HANDLE_REQUESTS = 100e-3
 
-  def __init__(self, port: int):
+  def __init__(self, port: int, local_ip: str):
     self._configurations = []
     self._condition = asyncio.Condition()
 
     self._running = False
 
-    local_ip = self._get_local_ip()
+    local_ip = local_ip or self._get_local_ip()
     self._json = {'local_reg': {'ip': local_ip, 'notify': 0, 'port': port, 'uri': '/local_lan'}}
 
   def _get_local_ip(self):

--- a/hassio/config.json
+++ b/hassio/config.json
@@ -21,7 +21,8 @@
     "mqtt_host": "core-mosquitto",
     "mqtt_user": null,
     "mqtt_pass": null,
-    "port": null
+    "port": null,
+    "local_ip": null
   },
   "schema": {
     "app": [
@@ -35,6 +36,7 @@
     "mqtt_host": "str?",
     "mqtt_user": "str?",
     "mqtt_pass": "str?",
-    "port": "port"
+    "port": "port",
+    "local_ip": "str?"
   }
 }

--- a/options.json
+++ b/options.json
@@ -10,5 +10,6 @@
   "mqtt_host": "localhost",
   "mqtt_user": "<mqtt username>",
   "mqtt_pass": "<mqtt password>",
-  "port": 8888
+  "port": 8888,
+  "local_ip": "<ip address of AirCon server>"
 }

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ LOG_LEVEL=$(jq -r '.log_level | ascii_upcase // "WARNING"' $OPTIONS_FILE)
 MQTT_HOST=$(jq -r '.mqtt_host // ""' $OPTIONS_FILE)
 MQTT_USER=$(jq -r 'if (.mqtt_user and .mqtt_pass) then (.mqtt_user + ":" + .mqtt_pass) else "" end' $OPTIONS_FILE)
 APPS=$(jq -r '.app | length // 0' $OPTIONS_FILE)
+LOCAL_IP=$(jq -r 'if (.local_ip) then (.local_ip) else "" end' $OPTIONS_FILE)
 
 mkdir -p $CONFIG_DIR
 if [ -z "$(find $CONFIG_DIR -maxdepth 1 -type f -name "config_*.json")" ]; then
@@ -23,4 +24,4 @@ configs=
 for i in $(find $CONFIG_DIR -maxdepth 1 -type f -name "config_*.json" -exec basename {} \;)
   do configs="$configs --config $CONFIG_DIR/$i --type $TYPE"
 done
-python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host "$MQTT_HOST" --mqtt_user "$MQTT_USER" $configs
+python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host "$MQTT_HOST" --mqtt_user "$MQTT_USER" --local_ip "$LOCAL_IP" $configs


### PR DESCRIPTION
This PR adds an option to (optionally) pass the local IP of the AirCon service as a configuration parameter.
While this is not ideal, it provides a workaround for #148 