### PR TITLE
Add a granularity property to round to nearest 0.5C

### DIFF
--- a/aircon/properties.py
+++ b/aircon/properties.py
@@ -153,7 +153,18 @@ class Properties(object):
 
   @classmethod
   def get_precision(cls, attr: str):
+    """Precision affects int values; they will be divided by the precision to get a result that's
+    sent to the device. A typical value is 0.1, which means that the value is multiplied by 10.
+    """
     return cls._get_metadata(attr).get('precision', 1)
+
+  @classmethod
+  def get_granularity(cls, attr: str):
+    """Granularity affects int values.  Any incoming float value v will be rounded to the nearest
+    granularity g by round(v/g) * g.  A typical value is 0.5.  Combined with precision of 0.1, this
+    can convert an incoming value of 20.1 to 200, or 20.4 to 205.
+    """
+    return cls._get_metadata(attr).get('granularity', 1)
 
   @classmethod
   def get_read_only(cls, attr: str):
@@ -404,6 +415,7 @@ class FglProperties(Properties):
                                   metadata={
                                       'base_type': 'integer',
                                       'precision': 0.1,
+                                      'granularity': 0.5,
                                       'read_only': False
                                   })
   af_vertical_direction: int = field(default=3,


### PR DESCRIPTION
I'm using FGLair-us with HA.  Even though my thermostats display in F, I have to set the `temp_type` to C to have anything function properly.  It appears that the actual adjust_temperature commands that the wifi units accept must be in increments of 0.5 C, but when I change the temperature in F in HA, AirCon currenly rounds to the nearest degree C, which means many temperature adjustments are no-ops (e.g. 70F to 69F results in no change, they both round to 21C).  

Here's an example log: 
```
hisense_ac    | I0327 04:41:57.734  mqtt_client.py:37] MQTT message Topic: hisense_ac/[redacted]/adjust_temperature/command, Payload b'20.555555555555554'
hisense_ac    | I0327 04:41:57.749  web_log.py:206] 192.168.2.161 [27/Mar/2023:04:41:57 +0000] "GET /local_lan/commands.json HTTP/1.1" 200 418 "-" "-"
hisense_ac    | I0327 04:42:09.753  mqtt_client.py:37] MQTT message Topic: hisense_ac/[redacted]/adjust_temperature/command, Payload b'20.0'
hisense_ac    | I0327 04:42:09.767  web_log.py:206] 192.168.2.161 [27/Mar/2023:04:42:09 +0000] "GET /local_lan/commands.json HTTP/1.1" 200 418 "-" "-"
hisense_ac    | I0327 04:42:10.790  query_handlers.py:139] Decrypted: {"seq_no":96,"data":{"name":"adjust_temperature","value":200}}
hisense_ac    | I0327 04:42:10.794  web_log.py:206] 192.168.2.161 [27/Mar/2023:04:42:10 +0000] "POST /local_lan/property/datapoint.json HTTP/1.1" 200 150 "-" "-"
hisense_ac    | I0327 04:42:16.766  mqtt_client.py:37] MQTT message Topic: hisense_ac/[redacted]/adjust_temperature/command, Payload b'21.11111111111111'
hisense_ac    | I0327 04:42:16.786  web_log.py:206] 192.168.2.161 [27/Mar/2023:04:42:16 +0000] "GET /local_lan/commands.json HTTP/1.1" 200 418 "-" "-"
hisense_ac    | I0327 04:42:19.773  query_handlers.py:139] Decrypted: {"seq_no":97,"data":{"name":"adjust_temperature","value":210}}
```

To account for this, I've added a "granularity" property that will round to the nearest 0.5C before the precision is applied.  This fixes the problem for me.

