### PR TITLE
Precision for fglair devices

### DIFF
--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -211,7 +211,7 @@ async def run(parsed_args):
                   'topic': mqtt_topics['pub'].format(device.mac_address, 'available')
               },
           ],
-          'precision': 1.0,
+          'precision': device.get_temp_precision(),
           'temperature_unit': 'F' if device.is_fahrenheit else 'C'
       }
       topics = device.topics

--- a/aircon/properties.py
+++ b/aircon/properties.py
@@ -153,7 +153,18 @@ class Properties(object):
 
   @classmethod
   def get_precision(cls, attr: str):
+    """Precision affects int values; they will be divided by the precision to get a result that's
+    sent to the device. A typical value is 0.1, which means that the value is multiplied by 10.
+    """
     return cls._get_metadata(attr).get('precision', 1)
+
+  @classmethod
+  def get_granularity(cls, attr: str):
+    """Granularity affects int values.  Any incoming float value v will be rounded to the nearest
+    granularity g by round(v/g) * g.  A typical value is 0.5.  Combined with precision of 0.1, this
+    can convert an incoming value of 20.1 to 200, or 20.4 to 205.
+    """
+    return cls._get_metadata(attr).get('granularity', 1)
 
   @classmethod
   def get_read_only(cls, attr: str):
@@ -404,6 +415,7 @@ class FglProperties(Properties):
                                   metadata={
                                       'base_type': 'integer',
                                       'precision': 0.1,
+                                      'granularity': 0.5,
                                       'read_only': False
                                   })
   af_vertical_direction: int = field(default=3,

--- a/aircon/properties.py
+++ b/aircon/properties.py
@@ -152,19 +152,19 @@ class Properties(object):
     return cls._get_metadata(attr)['base_type']
 
   @classmethod
-  def get_precision(cls, attr: str):
-    """Precision affects int values; they will be divided by the precision to get a result that's
-    sent to the device. A typical value is 0.1, which means that the value is multiplied by 10.
+  def get_scale(cls, attr: str) -> float:
+    """Scale affects int values; they will be divided by the scale to get a result that's
+    sent to the device, or multiplied when updating from the device. A typical value is 0.1.
     """
-    return cls._get_metadata(attr).get('precision', 1)
+    return cls._get_metadata(attr).get('scale', 1)
 
   @classmethod
-  def get_granularity(cls, attr: str):
-    """Granularity affects int values.  Any incoming float value v will be rounded to the nearest
-    granularity g by round(v/g) * g.  A typical value is 0.5.  Combined with precision of 0.1, this
+  def get_precision(cls, attr: str) -> float:
+    """Precision affects int values.  Any incoming float value v will be rounded to the nearest
+    precision g by round(v/g) * g.  A typical value is 0.5.  Combined with a scale of 0.1, this
     can convert an incoming value of 20.1 to 200, or 20.4 to 205.
     """
-    return cls._get_metadata(attr).get('granularity', 1)
+    return cls._get_metadata(attr).get('precision', 1)
 
   @classmethod
   def get_read_only(cls, attr: str):
@@ -414,8 +414,8 @@ class FglProperties(Properties):
   adjust_temperature: int = field(default=25,
                                   metadata={
                                       'base_type': 'integer',
-                                      'precision': 0.1,
-                                      'granularity': 0.5,
+                                      'scale': 0.1,
+                                      'precision': 0.5,
                                       'read_only': False
                                   })
   af_vertical_direction: int = field(default=3,
@@ -481,7 +481,7 @@ class FglBProperties(Properties):
   adjust_temperature: int = field(default=25,
                                   metadata={
                                       'base_type': 'integer',
-                                      'precision': 0.1,
+                                      'scale': 0.1,
                                       'read_only': False
                                   })
   af_vertical_move_step1: int = field(default=3,


### PR DESCRIPTION
For my device (a fujistu system that uses fglair-us) values go to/from the device in 10ths of a degree C, with a step of 0.5 degree; when controlling it in fahrenheit, 68ºF -> 200, 69ºF -> 205, 70ºF -> 210, etc.

I renamed the "precision" value to "scale", because it's really the scale factor for converting the temperature to/from the device value, and I added a new "precision" value that aligns with the "precision" value on HA's mqtt discovery topic; that is, how big the step is between two accepted temp values.

That precision value is now published to HA, and I'm able to control the temperature in HA to the degree F, where before it would ignore single-degree changes in F because it was rounding to the nearest degree C.

This supercedes #220 